### PR TITLE
2 new session errors and an update to report not found page

### DIFF
--- a/app/views/corecomponents/components/current/form_components/404-Error-page-v3.html
+++ b/app/views/corecomponents/components/current/form_components/404-Error-page-v3.html
@@ -1,0 +1,33 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+Report not found – Health Assessment Service – GOV.UK
+{% endblock %}
+
+
+
+{% block content %}
+
+
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-l">Report not found</h1>
+
+
+        <p class="govuk-body">
+          If you typed the web address, check it is correct.
+        </p>
+        <p class="govuk-body">
+          If you pasted the web address, check you copied the entire address.
+        </p>
+
+        <p class="govuk-body">
+    Go to the  <a href="#" class="govuk-link">last page you viewed</a>      </p>
+
+
+      </div>
+    </div>
+
+
+{% endblock %}

--- a/app/views/corecomponents/components/current/form_components/Error-session-link-expired.html
+++ b/app/views/corecomponents/components/current/form_components/Error-session-link-expired.html
@@ -1,0 +1,33 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Session did not load - Health Assessment Service
+{% endblock %}
+
+
+
+
+{% block content %}
+
+
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-l">Session not found</h1>
+
+
+        <p class="govuk-body">
+
+          If you have saved this web address, the address may no longer work. Reload the assessment you need from the health assessment start page.
+  </p>
+        <p class="govuk-body">
+          If you reached this page by selecting a link or button within the Health Assessment Service, go to DWP Place and select the option to 'report an incident'.
+        </p>
+
+
+      </div>
+    </div>
+
+
+
+{% endblock %}

--- a/app/views/corecomponents/components/current/form_components/Error-session-not-created.html
+++ b/app/views/corecomponents/components/current/form_components/Error-session-not-created.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Session did not load - Health Assessment Service
+{% endblock %}
+
+
+
+
+{% block content %}
+
+
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-l">Session not created</h1>
+
+
+        <p class="govuk-body">
+
+          If you have just started the assessment, try again.
+
+
+
+
+
+
+
+  </p>
+        <p class="govuk-body">
+        Go to the <a href="#">last page you viewed</a>
+        </p>
+
+        <p class="govuk-body">
+        If the problem persists, go to DWP Place and select the option to 'report an incident'.
+        </p>
+
+      </div>
+    </div>
+
+
+
+{% endblock %}

--- a/app/views/corecomponents/components/current/index_components.html
+++ b/app/views/corecomponents/components/current/index_components.html
@@ -235,7 +235,7 @@
   <h3 class="govuk-heading-m">Page error status</h3>
   <p class="govuk-body"></p>
   <li>
-    <a class="govuk-link" href="form_components/404-Error-page-v2">Page not found - 404 status</a>
+    <a class="govuk-link" href="form_components/404-Error-page-v3">Report not found - 404 status</a>
   </li>
   <li>
     <a class="govuk-link" href="form_components/500-serviceError-page-v2">Catch all error within assessment - 400-500 status </a>
@@ -250,7 +250,12 @@
     <a class="govuk-link" href="form_components/409-report-already-submitted">Report already submitted - 409 status </a>
   </li>
 
-
+  <li>
+    <a class="govuk-link" href="form_components/error-session-not-created">Session not created - 400 status</a>
+  </li>
+  <li>
+    <a class="govuk-link" href="form_components/error-session-link-expired">Session not found </a>
+  </li>
 
 <br>
 <h3 class="govuk-heading-m">Other status functions</h3>
@@ -349,7 +354,7 @@
     <p><a href="/reports_templates/v2_Aug21/report_full_assessment_UC_Telephone_Function_LCWRA_activity.html">WCA Report - add in activity</a></p>
 
     <p><a href="/reports/reports_templates/v2_Aug21/report_full_assessment_UC_Telephone_Function_LCWRA_styling.html">WCA Report - Style code</a></p>
-   
+
     <p><a href="/reports/reports_templates/v2_Aug21/report_full_assessment_UC_Telephone_Function_LCWRA_activity.html">WCA Report - add in activity</a></p>
 
 


### PR DESCRIPTION
These are the two new session errors that have been created off the back of the session refresh work. The developers are in agreement about 400, but may add more scope to the other error once they start working on it.